### PR TITLE
Add caching for array creation

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -1,8 +1,9 @@
 var fn = new Intl.Collator(0, { numeric:1 }).compare;
+var map = {};
 
 export default function (a, b) {
-	a = a.split('.');
-	b = b.split('.');
+	a = map[a] || (map[a] = a.split('.'));
+	b = map[b] || (map[b] = b.split('.'));
 
 	return fn(a[0], b[0])
 			|| fn(a[1], b[1])


### PR DESCRIPTION
Hi Luke! 👋 

Awesome nifty project! As usual! 💯 
I was looking over the source code and I spotted some perf improvement by caching the splitted array by using `a` and `b` as keys. This did improve the perf with around ~25% faster ops/s. Here's the bench https://esbench.com/bench/5ce263a14cd7e6009ef624f3.
![Screenshot 2019-05-20 at 12 13 55](https://user-images.githubusercontent.com/3405161/58010301-c3627b00-7af8-11e9-908b-a88a80df249b.png)


Adds `+20B`